### PR TITLE
Popravi zadnji primer

### DIFF
--- a/domace-naloge/01-agda/imp.agda
+++ b/domace-naloge/01-agda/imp.agda
@@ -178,4 +178,4 @@ evalCmd zero st (WHILE bexp DO cmd DONE) = st
 
 -- Pozor: tip funkcije ima smisel zgolj za osnovni tip rezultata
 vsotaPrvihN : Nat → Nat
-vsotaPrvihN n = (evalCmd 125 ( 0 :: (0 :: (0 :: []))) (vsota n)) [ 0 / 2 ]
+vsotaPrvihN n = (evalCmd 125 ( 0 :: (0 :: (0 :: []))) (vsota n)) [ 2 / 0 ]


### PR DESCRIPTION
V zadnjem primeru v domači nalogi je poklican indeks 0 / 2, v katerem je shranjen n, namesto indeksa 2 / 0, v katerem je shranjen rezultat.