### PR TITLE
Dodal manjkajoči konstruktor

### DIFF
--- a/domace-naloge/01-agda/imp.agda
+++ b/domace-naloge/01-agda/imp.agda
@@ -91,6 +91,7 @@ data Exp (n : Nat) : Set where
     _*_ : Exp n → Exp n → Exp n
 
 data BExp (n : Nat) : Set where
+    𝔹 : Bool → BExp n
     _≡_ : Exp n → Exp n → BExp n
     _<_ : Exp n → Exp n → BExp n
     _>_ : Exp n → Exp n → BExp n


### PR DESCRIPTION
Pri definiciji `BExp` je manjkal konstruktor tipa `Bool -> BExp n`.