### PR TITLE
funkcije vračajo monadičen rezultat

### DIFF
--- a/zapiski/11-monade.md
+++ b/zapiski/11-monade.md
@@ -155,7 +155,7 @@ $$
     \begin{align*}
     \itp{\boolty} &= \mathbb{B} = \{ \ttt, \fff \} \\
     \itp{\intty} &= \mathbb{Z} \\
-    \itp{A \to B} &= \itp{B}^{\itp{A}}
+    \itp{A \to B} &= \itp{B}^{T \itp{A}} = \itp{A} \to T \itp{B}
     \end{align*}
 $$
 


### PR DESCRIPTION
besedilo dol že to pravi, pa še to naredi pravilo za aplikacijo dejansko pravilno

in za lažje razumevanje sam dodal še puščično obliko interpretacije, ker intepretacije v potenci se izrišejo kot navadni `[]`